### PR TITLE
ci: enable firefox headless env variable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,6 @@ addons:
   chrome: stable
   firefox: latest
 
-cache:
-  directories:
-    - ./node_modules
-
 before_install:
   - google-chrome-stable --headless --disable-gpu --remote-debugging-port=9222 http://localhost &
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ node_js:
   - '12.0'
   - '13.0'
 
+env:
+  global:
+    - MOZ_HEADLESS=1
+
 addons:
   chrome: stable
   firefox: latest

--- a/projects/ng-imgix/karma.conf.js
+++ b/projects/ng-imgix/karma.conf.js
@@ -21,7 +21,7 @@ module.exports = function (config) {
       reports: ['html', 'lcovonly', 'text-summary'],
       fixWebpackSourcePaths: true
     },
-    reporters: ['progress', 'kjhtml'],
+    reporters: ['progress', 'kjhtml', 'dots'],
     port: 9876,
     colors: true,
     logLevel: config.LOG_INFO,

--- a/projects/ng-imgix/karma.conf.js
+++ b/projects/ng-imgix/karma.conf.js
@@ -25,7 +25,6 @@ module.exports = function (config) {
     port: 9876,
     colors: true,
     logLevel: config.LOG_INFO,
-    autoWatch: true,
     failOnEmptyTestSuite: true,
     browsers: ['Chrome', 'ChromeHeadlessCI', 'FirefoxHeadless'],
     customLaunchers: {

--- a/projects/ng-imgix/karma.conf.js
+++ b/projects/ng-imgix/karma.conf.js
@@ -26,6 +26,7 @@ module.exports = function (config) {
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: true,
+    failOnEmptyTestSuite: true,
     browsers: ['Chrome', 'ChromeHeadlessCI', 'FirefoxHeadless'],
     customLaunchers: {
       ChromeHeadlessCI: {

--- a/projects/ng-imgix/src/lib/ix-srcset.directive.spec.ts
+++ b/projects/ng-imgix/src/lib/ix-srcset.directive.spec.ts
@@ -100,4 +100,8 @@ describe('The ixSrcset attribute directive', () => {
   it('should not create a srcset on any untagged <img> elements', () => {
     expect(bareImg.attributes.srcset).toBeUndefined();
   });
+
+  it('should fail', () => {
+    expect(false).toBeTruthy();
+  })
 });


### PR DESCRIPTION
I noticed that Firefox headless tests were not executing (while still returning a successful status) in CI. This PR makes an attempt to debug that to match execution when run locally:

<img width="605" alt="image" src="https://user-images.githubusercontent.com/15919091/90567917-c6b33f00-e15f-11ea-9879-1b977c749e60.png">

The same tests run locally:

<img width="723" alt="image" src="https://user-images.githubusercontent.com/15919091/90568128-1eea4100-e160-11ea-82f1-c75736d72648.png">
