### PR TITLE
refactor: init class ixlib using project manifest version

### DIFF
--- a/projects/ng-imgix/src/lib/ix-srcset.directive.spec.ts
+++ b/projects/ng-imgix/src/lib/ix-srcset.directive.spec.ts
@@ -47,6 +47,7 @@ describe('The ixSrcset attribute directive', () => {
   let FLUID_SRCSET_PATTERN;
   let FIXED_IMG_PATTERN;
   let FIXED_SRCSET_PATTERN;
+  let IXLIB_PATTERN;
 
   beforeEach(() => {
     fixture = TestBed.configureTestingModule({
@@ -74,6 +75,9 @@ describe('The ixSrcset attribute directive', () => {
 
     // the expected patten for fixed srcset, e.g. '...?dpr=2 2x,'
     FIXED_SRCSET_PATTERN = /(?:[\w:\/\-.&=?])+ \dx/;
+
+    // used to test for the existence of an ixlib query parameter
+    IXLIB_PATTERN = /ixlib=ng-\d+\.\d+\.\d+/;
   });
 
   it('should be reflected on any elements it is attached to', () => {
@@ -106,5 +110,11 @@ describe('The ixSrcset attribute directive', () => {
 
   it('should not create a srcset on any untagged <img> elements', () => {
     expect(bareImg.attributes.srcset).toBeUndefined();
+  });
+
+  it('should have an ixlib parameter appended by default', () => {
+    des.map((el) => {
+      expect(IXLIB_PATTERN.exec(el.nativeElement.srcset)).toBeTruthy();
+    });
   });
 });

--- a/projects/ng-imgix/src/lib/ix-srcset.directive.ts
+++ b/projects/ng-imgix/src/lib/ix-srcset.directive.ts
@@ -1,5 +1,6 @@
 import { Directive, Input, ElementRef, OnInit } from '@angular/core';
 
+const PKG_VERSION = require('../../package.json').version;
 import URI from 'urijs';
 import ImgixClient from 'imgix-core-js';
 
@@ -10,7 +11,7 @@ import ImgixClient from 'imgix-core-js';
 export class IxSrcsetDirective implements OnInit {
   settings: any = {};
   @Input('ixSrcset') srcsetOptions: any = {};
-  VERSION = '0.0.1';
+  VERSION = PKG_VERSION;
 
   constructor(private el: ElementRef) {}
 
@@ -23,7 +24,7 @@ export class IxSrcsetDirective implements OnInit {
     };
 
     const imgix = new ImgixClient(this.settings);
-    imgix['settings'].libraryParam = `ng-${this.VERSION}`;
+    (imgix as any).settings.libraryParam = `ng-${this.VERSION}`;
 
     if (!this.el.nativeElement.sizes) {
       this.el.nativeElement.sizes = '100vw';


### PR DESCRIPTION
Reduces repeat work/added maintenance of updating the project version in multiple places by extracting the package version from package.json