### PR TITLE
config: add `@types/node` to project tsconfig

### DIFF
--- a/projects/ng-imgix/.gitignore
+++ b/projects/ng-imgix/.gitignore
@@ -1,0 +1,46 @@
+# See http://help.github.com/ignore-files/ for more about ignoring files.
+
+# compiled output
+/dist
+/tmp
+/out-tsc
+# Only exists if Bazel was run
+/bazel-out
+
+# dependencies
+/node_modules
+
+# profiling files
+chrome-profiler-events*.json
+speed-measure-plugin*.json
+
+# IDEs and editors
+/.idea
+.project
+.classpath
+.c9/
+*.launch
+.settings/
+*.sublime-workspace
+
+# IDE - VSCode
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+.history/*
+
+# misc
+/.sass-cache
+/connect.lock
+/coverage
+/libpeerconnection.log
+npm-debug.log
+yarn-error.log
+testem.log
+/typings
+
+# System Files
+.DS_Store
+Thumbs.db

--- a/projects/ng-imgix/package.json
+++ b/projects/ng-imgix/package.json
@@ -3,7 +3,8 @@
   "version": "0.0.1",
   "peerDependencies": {
     "@angular/common": "^8.2.14",
-    "@angular/core": "^8.2.14"
+    "@angular/core": "^8.2.14",
+    "@types/node": "^14.6.4"
   },
   "dependencies": {
     "imgix-core-js": "2.3.1",

--- a/projects/ng-imgix/tsconfig.lib.json
+++ b/projects/ng-imgix/tsconfig.lib.json
@@ -5,7 +5,9 @@
     "target": "es2015",
     "declaration": true,
     "inlineSources": true,
-    "types": [],
+    "types": [
+      "node"
+    ],
     "lib": [
       "dom",
       "es2018"


### PR DESCRIPTION
This PR attempts to fix a build issue introduced in #35 

Current solution:
- Includes `@types/node` definitions as a peer dependency of the package. This allows us to `require` the `package.json` in order to extract out the package version number. While this works, it is likely not the solution we want as [per this comment](https://github.com/imgix/ng-imgix/pull/77#discussion_r483464698).

Other solution:
- Replace the `require` with `import` which may circumvent the aforementioned issue. Reference: https://stackoverflow.com/a/48869478/10366522
- This currently results in a different issue with TS not being able to locate `package.json` under the `rootDir`. Reference: https://stackoverflow.com/a/61467483/10366522