### PR TITLE
feat: fluid/fixed modes to support modern placeholders

### DIFF
--- a/projects/ng-imgix/src/lib/imgix.component.spec.ts
+++ b/projects/ng-imgix/src/lib/imgix.component.spec.ts
@@ -207,7 +207,7 @@ describe('Imgix Component', () => {
     });
     it('ix-img should render a fluid image if width is passed as attribute with [fixed]="false" attribute', async () => {
       const test = await renderImgTemplate(
-        `<ix-img src="amsterdam.jpg" width="100" fixed="false"></ix-img>`,
+        `<ix-img src="amsterdam.jpg" width="100" [fixed]="false"></ix-img>`,
       );
 
       expectElementToHaveFluidSrcAndSrcSet(test.getComponent());

--- a/projects/ng-imgix/src/lib/imgix.component.spec.ts
+++ b/projects/ng-imgix/src/lib/imgix.component.spec.ts
@@ -4,6 +4,10 @@ import {
   RenderComponentOptions,
   screen,
 } from '@testing-library/angular';
+import {
+  expectElementToHaveFixedSrcAndSrcSet,
+  expectElementToHaveFluidSrcAndSrcSet,
+} from '../test/url-assert';
 import { ImgixConfig } from './imgix-config.service';
 import { ImgixComponent } from './imgix.component';
 import { NgImgixModule } from './ng-imgix.module';
@@ -181,6 +185,123 @@ describe('Imgix Component', () => {
 
         expect(test.getComponent().getAttribute(attribute)).toBe(expectedValue);
       });
+    });
+  });
+
+  describe('in fluid mode (no fixed props set)', () => {
+    it('ix-img should render a fluid image if width is passed as attribute with no fixed attribute', async () => {
+      const test = await renderImgTemplate(
+        `<ix-img src="amsterdam.jpg" width="100" ></ix-img>`,
+      );
+
+      expectElementToHaveFluidSrcAndSrcSet(test.getComponent());
+      expect(test.getComponent().getAttribute('width')).toBe('100');
+    });
+    it('ix-img should render a fluid image if width is passed as attribute with fixed="false" attribute', async () => {
+      const test = await renderImgTemplate(
+        `<ix-img src="amsterdam.jpg" width="100" fixed="false"></ix-img>`,
+      );
+
+      expectElementToHaveFluidSrcAndSrcSet(test.getComponent());
+      expect(test.getComponent().getAttribute('width')).toBe('100');
+    });
+    it('ix-img should render a fluid image if width is passed as attribute with [fixed]="false" attribute', async () => {
+      const test = await renderImgTemplate(
+        `<ix-img src="amsterdam.jpg" width="100" fixed="false"></ix-img>`,
+      );
+
+      expectElementToHaveFluidSrcAndSrcSet(test.getComponent());
+      expect(test.getComponent().getAttribute('width')).toBe('100');
+    });
+    it('a width attribute should be passed through to the underlying component', async () => {
+      const test = await renderImgTemplate(
+        `<ix-img src="amsterdam.jpg" width="100"></ix-img>`,
+      );
+      expect(test.getComponent().getAttribute('width')).toBe('100');
+    });
+    it('a width attribute should not be set on the underlying component if width is not passed', async () => {
+      const test = await renderImgTemplate(
+        `<ix-img src="amsterdam.jpg"></ix-img>`,
+      );
+      expect(test.getComponent().hasAttribute('width')).toBe(false);
+    });
+    it('a height attribute should be passed through to the underlying component', async () => {
+      const test = await renderImgTemplate(
+        `<ix-img src="amsterdam.jpg" height="100"></ix-img>`,
+      );
+      expect(test.getComponent().getAttribute('height')).toBe('100');
+    });
+    it('a height attribute should not be set on the underlying component if height is not passed', async () => {
+      const test = await renderImgTemplate(
+        `<ix-img src="amsterdam.jpg"></ix-img>`,
+      );
+      expect(test.getComponent().hasAttribute('height')).toBe(false);
+    });
+  });
+
+  describe('in fixed mode (fixed prop set, or width/height passed to imgixParams)', () => {
+    it('the src and srcset should be in fixed size mode when a width is passed to imgixParams', async () => {
+      const test = await renderImgTemplate(
+        `<ix-img src="amsterdam.jpg" [imgixParams]="{w: 100}" ></ix-img>`,
+      );
+
+      expectElementToHaveFixedSrcAndSrcSet(test.getComponent(), 100);
+    });
+    it('the src and srcset should be in fixed size mode when a fixed prop is passed to the element', async () => {
+      const test = await renderImgTemplate(
+        `<ix-img src="amsterdam.jpg" width="100" height="150" fixed></ix-img>`,
+      );
+
+      const el = test.getComponent();
+      expectElementToHaveFixedSrcAndSrcSet(el, 100);
+
+      expect(el.getAttribute('src')).toEqual(jasmine.stringMatching('w=100'));
+      expect(el.getAttribute('srcset')).toEqual(
+        jasmine.stringMatching('w=100'),
+      );
+      expect(el.getAttribute('src')).toEqual(jasmine.stringMatching('h=150'));
+      expect(el.getAttribute('srcset')).toEqual(
+        jasmine.stringMatching('h=150'),
+      );
+    });
+    it('the src and srcset should be in fixed size mode when a fixed="true" prop is passed to the element', async () => {
+      const test = await renderImgTemplate(
+        `<ix-img src="amsterdam.jpg" width="100" height="150" fixed="true"></ix-img>`,
+      );
+
+      const el = test.getComponent();
+      expectElementToHaveFixedSrcAndSrcSet(el, 100);
+
+      expect(el.getAttribute('src')).toEqual(jasmine.stringMatching('h=150'));
+      expect(el.getAttribute('srcset')).toEqual(
+        jasmine.stringMatching('h=150'),
+      );
+    });
+    it('the src and srcset should be in fixed size mode when a [fixed]="true" prop is passed to the element', async () => {
+      const test = await renderImgTemplate(
+        `<ix-img src="amsterdam.jpg" width="100" height="150" [fixed]="true"></ix-img>`,
+      );
+
+      const el = test.getComponent();
+      expectElementToHaveFixedSrcAndSrcSet(el, 100);
+
+      expect(el.getAttribute('src')).toEqual(jasmine.stringMatching('h=150'));
+      expect(el.getAttribute('srcset')).toEqual(
+        jasmine.stringMatching('h=150'),
+      );
+    });
+
+    it('a width attribute should be passed through to the underlying component', async () => {
+      const test = await renderImgTemplate(
+        `<ix-img src="amsterdam.jpg" width="100" fixed></ix-img>`,
+      );
+      expect(test.getComponent().getAttribute('width')).toBe('100');
+    });
+    it('a height attribute should be passed through to the underlying component', async () => {
+      const test = await renderImgTemplate(
+        `<ix-img src="amsterdam.jpg" height="100" fixed></ix-img>`,
+      );
+      expect(test.getComponent().getAttribute('height')).toBe('100');
     });
   });
 });

--- a/projects/ng-imgix/src/lib/imgix.component.spec.ts
+++ b/projects/ng-imgix/src/lib/imgix.component.spec.ts
@@ -158,4 +158,29 @@ describe('Imgix Component', () => {
 
     expect(test.getComponent().getAttribute('class')).toBe('img-class');
   });
+
+  describe('type guards', () => {
+    const TEST_CASES: [
+      html: string,
+      attribute: string,
+      expectedValue: string,
+    ][] = [
+      [`width="100"`, 'width', '100'],
+      [`width=100`, 'width', '100'],
+      [`[width]="100"`, 'width', '100'],
+      [`height="100"`, 'height', '100'],
+      [`height=100`, 'height', '100'],
+      [`[height]="100"`, 'height', '100'],
+    ];
+
+    TEST_CASES.map(([html, attribute, expectedValue]) => {
+      it(`${attribute} should be ${expectedValue} when the html attribute is ${html}`, async () => {
+        const test = await renderImgTemplate(
+          `<ix-img src="amsterdam.jpg" ${html}></ix-img>`,
+        );
+
+        expect(test.getComponent().getAttribute(attribute)).toBe(expectedValue);
+      });
+    });
+  });
 });

--- a/projects/ng-imgix/src/lib/imgix.component.ts
+++ b/projects/ng-imgix/src/lib/imgix.component.ts
@@ -54,7 +54,7 @@ export class ImgixComponent {
   set width(_width: number | undefined) {
     this._width = undefined;
 
-    const width = _width as unknown; // Using any for type safety
+    const width = _width as unknown; // Using unknown for type safety
 
     if (typeof width === 'string') {
       const widthParsed = Number.parseFloat(width);
@@ -75,7 +75,7 @@ export class ImgixComponent {
   set height(_height: number | undefined) {
     this._height = undefined;
 
-    const height = _height as unknown; // Using any for type safety
+    const height = _height as unknown; // Using unknown for type safety
 
     if (typeof height === 'string') {
       const heightParsed = Number.parseFloat(height);

--- a/projects/ng-imgix/src/lib/imgix.component.ts
+++ b/projects/ng-imgix/src/lib/imgix.component.ts
@@ -24,8 +24,49 @@ export class ImgixComponent {
   @Input() src: string;
   @Input() fixed?: boolean;
   @Input() imgixParams?: Object;
-  @Input() width?: string | number;
-  @Input() height?: string | number;
+
+  @Input()
+  get width(): number | undefined {
+    return this._width;
+  }
+  set width(_width: number | undefined) {
+    this._width = undefined;
+
+    const width = _width as unknown; // Using any for type safety
+
+    if (typeof width === 'string') {
+      const widthParsed = Number.parseFloat(width);
+      if (!Number.isNaN(widthParsed)) {
+        this._width = widthParsed;
+      }
+    }
+    if (typeof width === 'number' && !Number.isNaN(width)) {
+      this._width = width;
+    }
+  }
+  private _width: number | undefined;
+
+  @Input()
+  get height(): number | undefined {
+    return this._height;
+  }
+  set height(_height: number | undefined) {
+    this._height = undefined;
+
+    const height = _height as unknown; // Using any for type safety
+
+    if (typeof height === 'string') {
+      const heightParsed = Number.parseFloat(height);
+      if (!Number.isNaN(heightParsed)) {
+        this._height = heightParsed;
+      }
+    }
+    if (typeof height === 'number' && !Number.isNaN(height)) {
+      this._height = height;
+    }
+  }
+  private _height: number | undefined;
+
   @Input() attributeConfig?: Object;
   @Input() disableVariableQuality?: boolean;
 

--- a/projects/ng-imgix/src/lib/imgix.component.ts
+++ b/projects/ng-imgix/src/lib/imgix.component.ts
@@ -13,7 +13,13 @@ import { ImgixConfig, ImgixConfigService } from './imgix-config.service';
 @Component({
   // the [src] means that src is required
   selector: 'ix-img[src]',
-  template: `<img [src]="srcURL" [srcset]="srcsetURL" #v />`,
+  template: `<img
+    [attr.src]="srcURL"
+    [attr.srcset]="srcsetURL"
+    [attr.height]="height"
+    [attr.width]="width"
+    #v
+  />`,
 })
 export class ImgixComponent {
   private readonly client: ImgixClient;
@@ -22,7 +28,23 @@ export class ImgixComponent {
   v?: ElementRef<HTMLImageElement>;
 
   @Input() src: string;
-  @Input() fixed?: boolean;
+  @Input()
+  get fixed(): boolean {
+    return this._fixed;
+  }
+  set fixed(_fixed: boolean) {
+    this._fixed = false;
+    const fixed = _fixed as unknown;
+    if (
+      (typeof fixed === 'string' &&
+        (fixed.trim() === '' || fixed.trim() === 'true')) ||
+      (typeof fixed === 'boolean' && fixed === true)
+    ) {
+      this._fixed = true;
+    }
+  }
+  private _fixed: boolean = false;
+
   @Input() imgixParams?: Object;
 
   @Input()
@@ -89,8 +111,15 @@ export class ImgixComponent {
     );
   }
 
-  private buildIxParams(ixParams?: {}) {
+  private buildIxParams() {
+    const imgixParamsFromImgAttributes = {
+      ...(this.fixed && {
+        ...(this.width != null ? { w: this.width } : {}),
+        ...(this.height != null ? { h: this.height } : {}),
+      }),
+    };
     return {
+      ...imgixParamsFromImgAttributes,
       ...this.imgixParams,
     };
   }

--- a/projects/ng-imgix/src/test/url-assert.ts
+++ b/projects/ng-imgix/src/test/url-assert.ts
@@ -1,0 +1,54 @@
+export const stringMatchingFixedSrcSet = (width: number) =>
+  jasmine.stringMatching(new RegExp(`.*w=${width}&.*dpr=1.* 1x,`));
+
+export const expectSrcSetToBeFixed = (
+  srcset: string | null | undefined,
+  width: number,
+) => expect(srcset).toEqual(stringMatchingFixedSrcSet(width));
+
+export const expectElementToHaveFixedSrcSet = (
+  el: HTMLElement,
+  width: number,
+) => expectSrcSetToBeFixed(el.getAttribute('srcset'), width);
+
+export const stringMatchingFixedSrc = (width: number) =>
+  jasmine.stringMatching(new RegExp(`.*w=${width}`));
+
+export const expectSrcToBeFixed = (
+  src: string | null | undefined,
+  width: number,
+) => expect(src).toEqual(stringMatchingFixedSrc(width));
+
+export const expectElementToHaveFixedSrc = (el: HTMLElement, width: number) =>
+  expectSrcToBeFixed(el.getAttribute('src'), width);
+
+export const expectElementToHaveFixedSrcAndSrcSet = (
+  el: HTMLElement,
+  width: number,
+) => {
+  expectElementToHaveFixedSrc(el, width);
+  expectElementToHaveFixedSrcSet(el, width);
+};
+
+export const stringMatchingFluidSrcSet = () =>
+  jasmine.stringMatching(new RegExp(`.*w=100.* 100w,`));
+
+export const expectSrcSetToBeFluid = (srcset: string | null | undefined) =>
+  expect(srcset).toEqual(stringMatchingFluidSrcSet());
+
+export const expectElementToHaveFluidSrcSet = (el: HTMLElement) =>
+  expectSrcSetToBeFluid(el.getAttribute('srcset'));
+
+export const stringMatchingFluidSrc = () =>
+  jasmine.stringMatching(new RegExp(`^(?!.*w=).*$`));
+
+export const expectSrcToBeFluid = (src: string | null | undefined) =>
+  expect(src).toEqual(stringMatchingFluidSrc());
+
+export const expectElementToHaveFluidSrc = (el: HTMLElement) =>
+  expectSrcToBeFluid(el.getAttribute('src'));
+
+export const expectElementToHaveFluidSrcAndSrcSet = (el: HTMLElement) => {
+  expectElementToHaveFluidSrc(el);
+  expectElementToHaveFluidSrcSet(el);
+};


### PR DESCRIPTION
Note: this is stacked on another PR so the branch needs to be changed before merging.

---

This PR adds the implementation for the API that was started in Vue to support modern browser placeholder behaviour.