### PR TITLE
feat: allow the attribute names, that src and srcset are set to, to be changed

### DIFF
--- a/projects/ng-imgix/src/lib/imgix.component.spec.ts
+++ b/projects/ng-imgix/src/lib/imgix.component.spec.ts
@@ -304,4 +304,20 @@ describe('Imgix Component', () => {
       expect(test.getComponent().getAttribute('height')).toBe('100');
     });
   });
+
+  describe('attributeConfig', () => {
+    const ATTRIBUTES = ['src', 'srcset'];
+    ATTRIBUTES.forEach((attribute) => {
+      it(`${attribute} can be configured to use data-${attribute}`, async () => {
+        const test = await renderImgTemplate(
+          `<ix-img src="amsterdam.jpg" [attributeConfig]="{'${attribute}': 'data-${attribute}'}" ></ix-img>`,
+        );
+
+        expect(test.getComponent().getAttribute(`data-${attribute}`)).toMatch(
+          /ixlib/,
+        );
+        expect(test.getComponent().hasAttribute(attribute)).toBe(false);
+      });
+    });
+  });
 });

--- a/projects/ng-imgix/src/lib/imgix.component.ts
+++ b/projects/ng-imgix/src/lib/imgix.component.ts
@@ -1,4 +1,5 @@
 import {
+  AfterViewChecked,
   Component,
   ElementRef,
   Inject,
@@ -13,15 +14,9 @@ import { ImgixConfig, ImgixConfigService } from './imgix-config.service';
 @Component({
   // the [src] means that src is required
   selector: 'ix-img[src]',
-  template: `<img
-    [attr.src]="srcURL"
-    [attr.srcset]="srcsetURL"
-    [attr.height]="height"
-    [attr.width]="width"
-    #v
-  />`,
+  template: `<img [attr.height]="height" [attr.width]="width" #v />`,
 })
-export class ImgixComponent {
+export class ImgixComponent implements AfterViewChecked {
   private readonly client: ImgixClient;
 
   @ViewChild('v', { static: false })
@@ -89,7 +84,7 @@ export class ImgixComponent {
   }
   private _height: number | undefined;
 
-  @Input() attributeConfig?: Object;
+  @Input() attributeConfig?: { src?: string; srcset?: string };
   @Input() disableVariableQuality?: boolean;
 
   @Input() htmlAttributes?: Object;
@@ -100,8 +95,9 @@ export class ImgixComponent {
     });
   }
 
-  ngAfterViewInit() {
+  ngAfterViewChecked() {
     this.setHTMLAttributes();
+    this.setSrcAndSrcsetAttributes();
   }
 
   private setHTMLAttributes() {
@@ -122,6 +118,12 @@ export class ImgixComponent {
       ...imgixParamsFromImgAttributes,
       ...this.imgixParams,
     };
+  }
+
+  private setSrcAndSrcsetAttributes() {
+    const el = this.v.nativeElement;
+    el.setAttribute(this.attributeConfig?.src ?? 'src', this.srcURL);
+    el.setAttribute(this.attributeConfig?.srcset ?? 'srcset', this.srcsetURL);
   }
 
   get srcURL(): string {


### PR DESCRIPTION
ssia

```js
<ix-img src="image.jpg" [attributeConfig]="{src: 'data-src'}"></ix-img>
//-> <img data-src="https://.../image.jpg?..." />
```